### PR TITLE
fix: add repository information to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,5 +75,9 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org",
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Trac-Systems/trac-crypto-api"
   }
 }


### PR DESCRIPTION
I forgot to add information about repository in package.json. In the result `publish.yaml` pipeline is failing.